### PR TITLE
Fix invalid path in Getting Started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@ nav_order: 2
 These commands are intended to be run sequentially:
 
 - `git clone https://github.com/authelia/authelia.git`
-- `cd authelia/compose/local`
+- `cd compose/local`
 - `sudo ./setup.sh` *sudo is required to modify the `/etc/hosts` file*
 
 You can now visit the following locations; replace example.com with the domain you specified in the setup script:


### PR DESCRIPTION
I wanted to try `Authelia` but getting started is currently invalid so quick and simple commit to fix it.

I tried to find which commit made the `Getting Started` invalid but can't find it in the history:
``` shell
$ git log --full-history -1 -- authelia/compose/local/setup.sh
```

Duponin

PS: edit at line 34 looks to be a Github bug, it only appears when I do the Pull Request (change is done in web editor)